### PR TITLE
tweak: add styles for slim scrollbar

### DIFF
--- a/docs/.vitepress/theme/styles/custom.css
+++ b/docs/.vitepress/theme/styles/custom.css
@@ -15,3 +15,28 @@ pre, code, kbd, samp {
 .VPDoc .content-container img {
   border-radius: 5px;
 }
+
+/* slim scroll bar for windows based web browsers - works on chrome, edge, and safari */
+::-webkit-scrollbar {
+      width: 3px;
+        height: 3px;
+        
+}
+
+/* scrolling track/backgronund color */
+::-webkit-scrollbar-track {
+      background: #3b3b3b;
+      
+}
+
+/* scrolling handle */
+::-webkit-scrollbar-thumb {
+      background: #42b883;
+      
+}
+
+/* handle on hover */
+::-webkit-scrollbar-thumb:hover {
+      background: #36986c;
+      
+}

--- a/docs/.vitepress/theme/styles/custom.css
+++ b/docs/.vitepress/theme/styles/custom.css
@@ -16,27 +16,29 @@ pre, code, kbd, samp {
   border-radius: 5px;
 }
 
-/* slim scroll bar for windows based web browsers - works on chrome, edge, and safari */
-::-webkit-scrollbar {
-      width: 3px;
-        height: 3px;
-        
+/* slim scroll bar for windows based web browsers - works on firefox */
+* {
+  scrollbar-color: var(--vp-c-divider-light) var(--vp-button-alt-bg);
+  scrollbar-width: thin;
 }
 
-/* scrolling track/backgronund color */
-::-webkit-scrollbar-track {
-      background: #3b3b3b;
-      
+/* slim scroll bar for windows based web browsers - works on chrome, edge, and safari */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
 }
 
 /* scrolling handle */
 ::-webkit-scrollbar-thumb {
-      background: #42b883;
-      
+  background: var(--vp-c-divider-light);
 }
 
 /* handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-      background: #36986c;
-      
+  background: var(--vp-button-alt-hover-bg);
+}
+
+/* scrolling track/backgronund color */
+::-webkit-scrollbar-track {
+  background: var(--vp-button-alt-bg);
 }


### PR DESCRIPTION
Override default scrollbar styles of the traditional windows ver. via `custom/css` shown in the image below (also available through your `README` file),

![image](https://user-images.githubusercontent.com/101481353/196998209-fe8afaea-e8cc-4ece-8591-d8ca329c8b38.png)


into a slimmer version of the scrollbar with more coloured or more "vueified" element since the framework of this note site is based off vue/vitepress, image displayed below, both vertical and horizontal scrollbar included for this tweak.

![image](https://user-images.githubusercontent.com/101481353/197007689-85953aff-714b-4f18-bd21-ac6903875b40.png)

Both scrollbars of different orientations are fixed with the width of 3px based on the similar look on the scrollbar of the TOC section, as well the colour is default to `#42b883` as a regard to the vue regulation (not necessarily but yes a primary color pulled directly off from your site), as you may see in the extra css PRed into the file.

Other settings such as background scroll track colours alongside the on hover colour are also customizable based off personal preferences, comments are added.

>Note that **only** accept this PR if you feel it fits your flavor of choice, great looking customization on vitepress! I'll definitely take this as a template for my future projects, thanks! :)